### PR TITLE
Add a language selector

### DIFF
--- a/back/__init__.py
+++ b/back/__init__.py
@@ -5,12 +5,10 @@ def main(global_config, **settings):
     """ This function returns a Pyramid WSGI application."""
     with Configurator(settings=settings) as config:
         config.include('.models')
+        config.include('.i18n')
         config.include('pyramid_jinja2')
         config.include('.routes')
         config.include('.security')
-
-        config.add_translation_dirs('back:locale/')
-        config.set_locale_negotiator(lambda r: 'en')
 
         config.scan()
     return config.make_wsgi_app()

--- a/back/i18n.py
+++ b/back/i18n.py
@@ -1,0 +1,18 @@
+from pyramid.i18n import default_locale_negotiator
+from pyramid.settings import aslist
+
+
+def locale_negotiator(request):
+    available_locales = aslist(request.registry.settings['available_locales'])
+    default_locale = request.registry.settings['pyramid.default_locale_name']
+    locale = default_locale_negotiator(request)
+
+    if locale in available_locales:
+        return locale
+
+    return request.accept_language.best_match(available_locales, default_locale)
+
+
+def includeme(config):
+    config.add_translation_dirs('back:locale/')
+    config.set_locale_negotiator(locale_negotiator)

--- a/back/templates/layout.jinja2
+++ b/back/templates/layout.jinja2
@@ -31,6 +31,21 @@
   </head>
 
   <body>
+    <!-- START language selector -->
+    <div class="float-right">
+      Language:&nbsp;
+      <select id="language" data-toggle="tooltip" title="Uses a cookie to store the selected language.">{{ _("use_my_location") }}>
+        {% for l in request.registry.settings.get('available_locales').split(' ') %}
+          {% if l == request.locale_name %}
+            <option value="{{ l }}" selected>{{ l }}</option>
+          {% else %}
+            <option value="{{ l }}">{{ l }}</option>
+          {% endif %}
+        {% endfor %}
+      </select>
+    </div>
+    <!-- END language selector -->
+
     {% block content %}
         <p>No content</p>
     {% endblock content %}
@@ -123,6 +138,7 @@
   });
 
   </script>
+  <script type="text/javascript" src="{{request.static_url('back:static/main.js')}}"></script>
     {% block bottom_js %}
     {% endblock %}
   </body>

--- a/development.ini
+++ b/development.ini
@@ -18,6 +18,8 @@ sqlalchemy.url = sqlite:///%(here)s/back.sqlite
 
 retry.attempts = 3
 
+available_locales = en sl
+
 # By default, the toolbar only appears for clients from IP addresses
 # '127.0.0.1' and '::1'.
 # debugtoolbar.hosts = 127.0.0.1 ::1

--- a/production.ini
+++ b/production.ini
@@ -16,6 +16,8 @@ sqlalchemy.url = sqlite:///%(here)s/back.sqlite
 
 retry.attempts = 3
 
+available_locales = en sl
+
 [pshell]
 setup = back.pshell.setup
 


### PR DESCRIPTION
Adds "available languages" config key, guesses locale, based on preferred language and uses a "_LOCALE_" cookie to store the language (if language selected via dropdown in the top of the page)

![Screenshot from 2020-03-12 16-23-33](https://user-images.githubusercontent.com/4228250/76537618-51d82c80-647e-11ea-9e89-43f4f53f3fe8.png)

Fix #11, fix #6.